### PR TITLE
Patch jitpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Note: This library is still under development, and some concepts or features mig
 ```
 	dependencies {
             ...
-            implementation 'com.github.CST-Group:meca:0.1.0'
+            implementation 'com.github.CST-Group:meca:0.1.1'
 	}
 ```
 
@@ -51,7 +51,7 @@ Note: This library is still under development, and some concepts or features mig
 	<dependency>
 	    <groupId>com.github.CST-Group</groupId>
 	    <artifactId>meca</artifactId>
-	    <version>0.1.0</version>
+	    <version>0.1.1</version>
 	</dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/CST-Group/meca.svg?branch=master)](https://travis-ci.org/CST-Group/meca) [![Maintainability](https://api.codeclimate.com/v1/badges/c24e46ebcdc9aa6a035e/maintainability)](https://codeclimate.com/github/CST-Group/meca/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/c24e46ebcdc9aa6a035e/test_coverage)](https://codeclimate.com/github/CST-Group/meca/test_coverage)
+[![](https://jitpack.io/v/CST-Group/meca.svg?label=Release)](https://jitpack.io/#CST-Group/meca)
 
 # MECA
 This Repository contains the source code of the **Multipurpose Enhanced Cognitive Architecture (MECA)**.

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ repositories {
 }
 
 dependencies {
-   api 'com.github.CST-Group:cst:0.2.3'
+   api 'com.github.CST-Group:cst:0.2.4'
    testImplementation group: 'junit', name: 'junit', version: '4.9'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,10 @@
 plugins {
 	id 'java-library-distribution'
   	id 'jacoco'
+  	id 'maven'
 }
+
+group = 'com.github.CST-Group'
 
 sourceSets {
    main {
@@ -21,7 +24,7 @@ description = "The Multipurpose Enhanced Cognitive Architecture (MECA)"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
-version = '0.1.0'
+version = '0.1.1'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
### Why was it necessary?
According to [Jitpack docs](https://jitpack.io/docs/BUILDING/), it is important to have the `maven` plugin in the `build.gradle`.

### How was it done?

Added the `maven` plugin in the `build.gradle` and also the `group` tag, as specified in the docs.

### How to test?

Import MECA library as in the `README` docs!
