### PR TITLE
Rosservice bind bug cst update

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Note: This library is still under development, and some concepts or features mig
 ```
 	dependencies {
             ...
-            implementation 'com.github.CST-Group:meca:0.2.0'
+            implementation 'com.github.CST-Group:meca:0.2.1'
 	}
 ```
 
@@ -53,7 +53,7 @@ Sometimes, the version number (tag) in this README gets out of date, as maintain
 	<dependency>
 	    <groupId>com.github.CST-Group</groupId>
 	    <artifactId>meca</artifactId>
-	    <version>0.2.0</version>
+	    <version>0.2.1</version>
 	</dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-   api 'com.github.CST-Group:cst:d437ccee7df5b1a66c451df20b468962f982df9b'
+   api 'com.github.CST-Group:cst:13dc3abbc23c420ce7ffb928d7fccf806022db5e'
    testImplementation group: 'junit', name: 'junit', version: '4.12'
    testImplementation 'org.ros.rosjava_messages:std_msgs:0.5.11'
    testImplementation 'org.ros.rosjava_messages:rosjava_test_msgs:0.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-   api 'com.github.CST-Group:cst:13dc3abbc23c420ce7ffb928d7fccf806022db5e'
+   api 'com.github.CST-Group:cst:0.3.1'
    testImplementation group: 'junit', name: 'junit', version: '4.12'
    testImplementation 'org.ros.rosjava_messages:std_msgs:0.5.11'
    testImplementation 'org.ros.rosjava_messages:rosjava_test_msgs:0.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ description = "The Multipurpose Enhanced Cognitive Architecture (MECA)"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
-version = '0.2.0'
+version = '0.2.1'
 
 repositories {
     mavenCentral()
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-   api 'com.github.CST-Group:cst:0.3.0'
+   api 'com.github.CST-Group:cst:d437ccee7df5b1a66c451df20b468962f982df9b'
    testImplementation group: 'junit', name: 'junit', version: '4.12'
    testImplementation 'org.ros.rosjava_messages:std_msgs:0.5.11'
    testImplementation 'org.ros.rosjava_messages:rosjava_test_msgs:0.3.0'

--- a/src/test/java/br/unicamp/meca/system1/codelets/rosservice/RosServiceClientTest.java
+++ b/src/test/java/br/unicamp/meca/system1/codelets/rosservice/RosServiceClientTest.java
@@ -82,4 +82,55 @@ public class RosServiceClientTest {
 		mecaMind.shutDown();
     
     }
+    
+    @Test
+    public void testRosServiceCallTwice() throws URISyntaxException, InterruptedException {
+    	
+		AddTwoIntService addTwoIntService = new AddTwoIntService();
+		NodeMainExecutor nodeMainExecutor = DefaultNodeMainExecutor.newDefault();
+		NodeConfiguration nodeConfiguration = NodeConfiguration.newPublic("127.0.0.1",new URI("http://127.0.0.1:11311"));
+		nodeMainExecutor.execute(addTwoIntService, nodeConfiguration);	
+		
+		Thread.sleep(2000);
+		
+		MecaMind mecaMind = new MecaMind("RosServiceClient");
+		
+		List<IMotorCodelet> motorCodelets = new ArrayList<>();
+		
+		AddTwoIntServiceClient addTwoIntServiceClient = new AddTwoIntServiceClient("127.0.0.1",new URI("http://127.0.0.1:11311"));
+		motorCodelets.add(addTwoIntServiceClient);
+    
+		mecaMind.setIMotorCodelets(motorCodelets);
+	    
+	    mecaMind.mountMecaMind();		
+		
+		mecaMind.start();
+		
+		Thread.sleep(5000);
+		
+		Memory motorMemory = addTwoIntServiceClient.getInput(addTwoIntServiceClient.getId());
+		
+		Integer expectedSum = 5;
+		
+		Integer[] numsToSum = new Integer[] {2,3};
+		motorMemory.setI(numsToSum);
+		
+		Thread.sleep(2000);
+		
+		assertEquals(expectedSum, addTwoIntServiceClient.getSum());
+		
+		expectedSum = 6;
+		
+		numsToSum = new Integer[] {3,3};
+		motorMemory.setI(numsToSum);
+		
+		Thread.sleep(2000);
+		
+		assertEquals(expectedSum, addTwoIntServiceClient.getSum());
+		
+		nodeMainExecutor.shutdownNodeMain(addTwoIntService);
+		
+		mecaMind.shutDown();
+    
+    }
 }


### PR DESCRIPTION
### Why was it necessary?

This PR was meant to update CST version. The CST patch corrects a small bug in the RosServiceCodelet binding.

### How was it done?

Just bumped CST version.

### How to test?

A unit test was written to test the new capacity was calling a service twice from the same ros service codelet.

### Future works

No more in this direction now.
