### PR TITLE
Changes to ActivityCodelet and ActivityTrackingCodelet 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Note: This library is still under development, and some concepts or features mig
 ```
 	dependencies {
             ...
-            implementation 'com.github.CST-Group:meca:0.4.2'
+            implementation 'com.github.CST-Group:meca:0.4.3'
 	}
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ description = "The Multipurpose Enhanced Cognitive Architecture (MECA)"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
-version = '0.4.2'
+version = '0.4.3'
 
 repositories {
     mavenCentral()

--- a/src/main/java/br/unicamp/meca/models/ActionSequencePlan.java
+++ b/src/main/java/br/unicamp/meca/models/ActionSequencePlan.java
@@ -46,7 +46,7 @@ public class ActionSequencePlan {
 	/**
 	 * Returns the ActionStep of the current ActionFromPlanningCodelet to be undertaken in the plan.
 	 * 
-	 * @return currentActionId
+	 * @return the current ActionStep 
 	 */
 	public ActionStep getCurrentActionStep() {
 		return actionIdSequence[currentActionIdIndex];
@@ -55,9 +55,9 @@ public class ActionSequencePlan {
         /**
 	 * Returns the ActionStep of the last ActionFromPlanningCodelet to be undertaken in the plan, or null if it is the first step.
 	 * 
-	 * @return currentActionId
+	 * @return the last ActionStep
 	 */
-	public ActionStep getLastActionStep() {
+	public ActionStep getLastExecutedActionStep() {
             if (currentActionIdIndex == 0) return(actionIdSequence[actionIdSequence.length-1]);
             else return actionIdSequence[currentActionIdIndex-1];
 	}
@@ -74,10 +74,10 @@ public class ActionSequencePlan {
 	/**
          * Forces a new actionStepSequence
          * 
-	 * @param actionIdSequence the actionIdSequence to set
+	 * @param actionStepSequence the actionIdSequence to set
 	 */
-	public void setActionStepSequence(ActionStep[] actionIdSequence) {
-		this.actionIdSequence = actionIdSequence;
+	public void setActionStepSequence(ActionStep[] actionStepSequence) {
+		this.actionIdSequence = actionStepSequence;
 	}
 
 	/**

--- a/src/main/java/br/unicamp/meca/models/ActionSequencePlan.java
+++ b/src/main/java/br/unicamp/meca/models/ActionSequencePlan.java
@@ -44,15 +44,27 @@ public class ActionSequencePlan {
 	}
 	
 	/**
-	 * Returns the id of the current ActionFromPlanningCodelet to be undertaken in the plan.
+	 * Returns the ActionStep of the current ActionFromPlanningCodelet to be undertaken in the plan.
 	 * 
 	 * @return currentActionId
 	 */
 	public ActionStep getCurrentActionStep() {
 		return actionIdSequence[currentActionIdIndex];
 	}
+        
+        /**
+	 * Returns the ActionStep of the last ActionFromPlanningCodelet to be undertaken in the plan, or null if it is the first step.
+	 * 
+	 * @return currentActionId
+	 */
+	public ActionStep getLastActionStep() {
+            if (currentActionIdIndex == 0) return(actionIdSequence[actionIdSequence.length-1]);
+            else return actionIdSequence[currentActionIdIndex-1];
+	}
 
 	/**
+         * get the array of ActionSteps which are related to the ActionSequencePlan
+         * 
 	 * @return the actionIdSequence
 	 */
 	public ActionStep[] getActionStepSequence() {
@@ -60,6 +72,8 @@ public class ActionSequencePlan {
 	}
 
 	/**
+         * Forces a new actionStepSequence
+         * 
 	 * @param actionIdSequence the actionIdSequence to set
 	 */
 	public void setActionStepSequence(ActionStep[] actionIdSequence) {
@@ -80,13 +94,18 @@ public class ActionSequencePlan {
 		this.currentActionIdIndex = currentActionIdIndex;
 	}
         
+        /**
+	 * Go to next action. If the action is the last in the plan, go to the first action 
+	 */
         public void gotoNextAction() {
+            actionIdSequence[currentActionIdIndex].executed = true;
             if (currentActionIdIndex < actionIdSequence.length-1)
                 currentActionIdIndex++;
+            else currentActionIdIndex = 0;
         }
         
         public String toString() {
-            String output = "{ ";
+            String output = "{";
             int i=0;
             for (ActionStep a : actionIdSequence) {
                 output += a.toString();
@@ -96,5 +115,14 @@ public class ActionSequencePlan {
             }
             output += "}";
             return(output);
+        }
+        
+        /**
+         * Reset the plan. Set all the action steps executed flag to false. 
+         */
+        public void resetPlan() {
+            for (ActionStep as : actionIdSequence) {
+                as.executed = false;
+            }
         }
 }

--- a/src/main/java/br/unicamp/meca/models/ActionStep.java
+++ b/src/main/java/br/unicamp/meca/models/ActionStep.java
@@ -24,6 +24,8 @@ import java.util.Map;
 public abstract class ActionStep {
     String actionId;
     Map<String,Object> parameters;
+    public boolean needsConclusion = false;
+    public boolean executed = false;
     
     public ActionStep() {
         actionId = "";

--- a/src/main/java/br/unicamp/meca/system1/codelets/ActivityCodelet.java
+++ b/src/main/java/br/unicamp/meca/system1/codelets/ActivityCodelet.java
@@ -93,7 +93,8 @@ public abstract class ActivityCodelet extends Codelet {
 				
 				for(String perceptualCodeletId : perceptualCodeletsIds) {
 					Memory perceptualMemory = this.getInput(perceptualCodeletId, index);
-					perceptualMemories.add(perceptualMemory);
+					if (perceptualMemory != null)
+                                            perceptualMemories.add(perceptualMemory);
 				}
 			}
 		}
@@ -107,7 +108,8 @@ public abstract class ActivityCodelet extends Codelet {
 				for(String motivationalCodeletsId : motivationalCodeletsIds)
 				{
 					Memory inputDrive = this.getInput(motivationalCodeletsId + "Drive");
-					driveMemories.add(inputDrive);
+                                        if (inputDrive != null)
+                                            driveMemories.add(inputDrive);
 				}
 			}
 		}
@@ -168,11 +170,20 @@ public abstract class ActivityCodelet extends Codelet {
 	public void proc() {		
 		if(actionSequencePlanMemoryContainer != null && actionSequencePlanMemoryContainer.getI() != null && actionSequencePlanMemoryContainer.getI() instanceof ActionSequencePlan) {
 			ActionSequencePlan actionSequencePlan = (ActionSequencePlan) actionSequencePlanMemoryContainer.getI();
-			String currentActionId = actionSequencePlan.getCurrentActionStep().getActionId();
+			ActionStep currentAction = actionSequencePlan.getCurrentActionStep();
+                        String currentActionId = currentAction.getActionId();
 
-			if(currentActionId != null && currentActionId.equalsIgnoreCase(id)) {
+			if(currentActionId != null && currentActionId.equalsIgnoreCase(id) && currentAction.executed == false) {
 				proc(perceptualMemories, broadcastMemory, motorMemory);
 			}
+                        else {
+                            ActionStep lastActionStep = actionSequencePlan.getLastActionStep();
+                            String lastActionId = lastActionStep.getActionId();
+                            if (lastActionStep != null && lastActionStep.needsConclusion && lastActionId.equalsIgnoreCase(id)) {
+                                doConclusion(perceptualMemories, broadcastMemory, motorMemory);
+                                lastActionStep.needsConclusion = false;
+                            }
+                        }
 		}else {
 			proc(perceptualMemories, broadcastMemory, motorMemory);
 		}
@@ -189,6 +200,19 @@ public abstract class ActivityCodelet extends Codelet {
 	 * 			the output motor memory.
 	 */
 	public abstract void proc(ArrayList<Memory> perceptualMemories, Memory broadcastMemory, Memory motorMemory);
+        
+        /**
+	 * Method to be called to do the Conclusion of an ActionStep, after its activities are over. 
+         * Similar to the proc method, but to be called one last time to clean whatever needs to be cleaned at the motorMemory
+	 * 
+	 * @param perceptualMemories
+	 * 			the input memories coming from perception.
+	 * @param broadcastMemory
+	 * 			the input memory coming from the conscious planner broadcast.
+	 * @param motorMemory
+	 * 			the output motor memory.
+	 */
+	public abstract void doConclusion(ArrayList<Memory> perceptualMemories, Memory broadcastMemory, Memory motorMemory);
 
 	/**
 	 * Returns the id of the Soar Codelet whose outputs will be read by this
@@ -278,4 +302,24 @@ public abstract class ActivityCodelet extends Codelet {
 	public ArrayList<String> getMotivationalCodeletsIds() {
 		return motivationalCodeletsIds;
 	}
+        
+        public ArrayList<Memory> getPerceptionMemories() {
+            return(perceptualMemories);
+        }
+        
+        public ArrayList<Memory> getDriveMemories() {
+            return(driveMemories);
+        }
+        
+        public Memory getBroadcastMemory() {
+            return(broadcastMemory);
+        }
+        
+        public Memory getActionSequencePlanMemoryContainer() {
+            return(actionSequencePlanMemoryContainer);
+        }
+        
+        public Memory getMotorMemory() {
+            return(motorMemory);
+        }
 }

--- a/src/main/java/br/unicamp/meca/system1/codelets/ActivityCodelet.java
+++ b/src/main/java/br/unicamp/meca/system1/codelets/ActivityCodelet.java
@@ -177,7 +177,7 @@ public abstract class ActivityCodelet extends Codelet {
 				proc(perceptualMemories, broadcastMemory, motorMemory);
 			}
                         else {
-                            ActionStep lastActionStep = actionSequencePlan.getLastActionStep();
+                            ActionStep lastActionStep = actionSequencePlan.getLastExecutedActionStep();
                             String lastActionId = lastActionStep.getActionId();
                             if (lastActionStep != null && lastActionStep.needsConclusion && lastActionId.equalsIgnoreCase(id)) {
                                 doConclusion(perceptualMemories, broadcastMemory, motorMemory);

--- a/src/main/java/br/unicamp/meca/system1/codelets/ActivityCodelet.java
+++ b/src/main/java/br/unicamp/meca/system1/codelets/ActivityCodelet.java
@@ -93,7 +93,8 @@ public abstract class ActivityCodelet extends Codelet {
 				
 				for(String perceptualCodeletId : perceptualCodeletsIds) {
 					Memory perceptualMemory = this.getInput(perceptualCodeletId, index);
-					perceptualMemories.add(perceptualMemory);
+					if (perceptualMemory != null)
+                                            perceptualMemories.add(perceptualMemory);
 				}
 			}
 		}
@@ -107,7 +108,8 @@ public abstract class ActivityCodelet extends Codelet {
 				for(String motivationalCodeletsId : motivationalCodeletsIds)
 				{
 					Memory inputDrive = this.getInput(motivationalCodeletsId + "Drive");
-					driveMemories.add(inputDrive);
+                                        if (inputDrive != null)
+                                            driveMemories.add(inputDrive);
 				}
 			}
 		}
@@ -168,11 +170,21 @@ public abstract class ActivityCodelet extends Codelet {
 	public void proc() {		
 		if(actionSequencePlanMemoryContainer != null && actionSequencePlanMemoryContainer.getI() != null && actionSequencePlanMemoryContainer.getI() instanceof ActionSequencePlan) {
 			ActionSequencePlan actionSequencePlan = (ActionSequencePlan) actionSequencePlanMemoryContainer.getI();
-			String currentActionId = actionSequencePlan.getCurrentActionStep().getActionId();
+			ActionStep currentAction = actionSequencePlan.getCurrentActionStep();
+                        String currentActionId = currentAction.getActionId();
 
-			if(currentActionId != null && currentActionId.equalsIgnoreCase(id)) {
+			if(currentActionId != null && currentActionId.equalsIgnoreCase(id) && currentAction.executed == false) {
 				proc(perceptualMemories, broadcastMemory, motorMemory);
 			}
+                        else {
+                            ActionStep lastActionStep = actionSequencePlan.getLastActionStep();
+                            String lastActionId = lastActionStep.getActionId();
+                            if (lastActionStep != null && lastActionStep.needsConclusion && lastActionId.equalsIgnoreCase(id)) {
+                                System.out.println("CurrentID: "+actionSequencePlan.getCurrentActionIdIndex()+" CurrentActionStep: "+currentActionId+" LastActionStep: "+lastActionStep.getActionId());
+                                doConclusion(perceptualMemories, broadcastMemory, motorMemory);
+                                lastActionStep.needsConclusion = false;
+                            }
+                        }
 		}else {
 			proc(perceptualMemories, broadcastMemory, motorMemory);
 		}
@@ -189,6 +201,19 @@ public abstract class ActivityCodelet extends Codelet {
 	 * 			the output motor memory.
 	 */
 	public abstract void proc(ArrayList<Memory> perceptualMemories, Memory broadcastMemory, Memory motorMemory);
+        
+        /**
+	 * Method to be called to do the Conclusion of an ActionStep, after its activities are over. 
+         * Similar to the proc method, but to be called one last time to clean whatever needs to be cleaned at the motorMemory
+	 * 
+	 * @param perceptualMemories
+	 * 			the input memories coming from perception.
+	 * @param broadcastMemory
+	 * 			the input memory coming from the conscious planner broadcast.
+	 * @param motorMemory
+	 * 			the output motor memory.
+	 */
+	public abstract void doConclusion(ArrayList<Memory> perceptualMemories, Memory broadcastMemory, Memory motorMemory);
 
 	/**
 	 * Returns the id of the Soar Codelet whose outputs will be read by this
@@ -278,4 +303,24 @@ public abstract class ActivityCodelet extends Codelet {
 	public ArrayList<String> getMotivationalCodeletsIds() {
 		return motivationalCodeletsIds;
 	}
+        
+        public ArrayList<Memory> getPerceptionMemories() {
+            return(perceptualMemories);
+        }
+        
+        public ArrayList<Memory> getDriveMemories() {
+            return(driveMemories);
+        }
+        
+        public Memory getBroadcastMemory() {
+            return(broadcastMemory);
+        }
+        
+        public Memory getActionSequencePlanMemoryContainer() {
+            return(actionSequencePlanMemoryContainer);
+        }
+        
+        public Memory getMotorMemory() {
+            return(motorMemory);
+        }
 }

--- a/src/main/java/br/unicamp/meca/system1/codelets/ActivityTrackingCodelet.java
+++ b/src/main/java/br/unicamp/meca/system1/codelets/ActivityTrackingCodelet.java
@@ -100,12 +100,14 @@ public class ActivityTrackingCodelet extends Codelet {
           perceptualMemories != null && 
           perceptualMemories.size() > 0) {
           ActionStep currentActionStep = actionSequencePlan.getCurrentActionStep();
-          ActionStep lastActionStep = actionSequencePlan.getLastActionStep();
-          if (actionSequencePlan.getCurrentActionIdIndex() == 0 || lastActionStep.needsConclusion == false) {
-            if (currentActionStep != null  && currentActionStep.executed == false && currentActionStep.stopCondition(perceptualMemories)) {
-                currentActionStep.needsConclusion = true;
-                actionSequencePlan.gotoNextAction();       
-            }        
+          ActionStep lastActionStep = actionSequencePlan.getLastExecutedActionStep();
+          if ((actionSequencePlan.getCurrentActionIdIndex() == 0 
+                || lastActionStep.needsConclusion == false) // you can go to next step if it is the first step of the plan or if the last step is clear
+                && (currentActionStep != null // then just check if current ActionStep is not null to avoid breaking the next tests
+                && currentActionStep.executed == false // the ActionStep was not already executed
+                && currentActionStep.stopCondition(perceptualMemories)) ) { // and the ActionStep reached its final destination 
+                    currentActionStep.needsConclusion = true;
+                    actionSequencePlan.gotoNextAction();       
           }
         }
     }

--- a/src/main/java/br/unicamp/meca/system1/codelets/ActivityTrackingCodelet.java
+++ b/src/main/java/br/unicamp/meca/system1/codelets/ActivityTrackingCodelet.java
@@ -100,18 +100,22 @@ public class ActivityTrackingCodelet extends Codelet {
           perceptualMemories != null && 
           perceptualMemories.size() > 0) {
           ActionStep currentActionStep = actionSequencePlan.getCurrentActionStep();
-          if (currentActionStep.stopCondition(perceptualMemories)) {
-            actionSequencePlan.gotoNextAction();       
-          }        
+          ActionStep lastActionStep = actionSequencePlan.getLastActionStep();
+          if (actionSequencePlan.getCurrentActionIdIndex() == 0 || lastActionStep.needsConclusion == false) {
+            if (currentActionStep != null  && currentActionStep.executed == false && currentActionStep.stopCondition(perceptualMemories)) {
+                currentActionStep.needsConclusion = true;
+                actionSequencePlan.gotoNextAction();       
+            }        
+          }
         }
     }
 	
 	@Override
 	public void proc() {
-		
-		actionSequencePlan = (ActionSequencePlan) actionSequencePlanMemoryContainer.getI();
-		
-		trackActionSequencePlan(perceptualMemories, actionSequencePlan);
+		if (actionSequencePlanMemoryContainer != null) {
+                    actionSequencePlan = (ActionSequencePlan) actionSequencePlanMemoryContainer.getI();
+                    trackActionSequencePlan(perceptualMemories, actionSequencePlan);
+                }    
 	}
 
 	/**

--- a/src/test/java/br/unicamp/meca/mind/action/Test1ActivityCodelet.java
+++ b/src/test/java/br/unicamp/meca/mind/action/Test1ActivityCodelet.java
@@ -29,8 +29,8 @@ public class Test1ActivityCodelet extends ActivityCodelet {
         
         @Override
 	public void doConclusion(ArrayList<Memory> perceptualMemories, Memory broadcastMemory, Memory motorMemory) {
-             System.out.println("Concluding Test1Activity");
-             ((MemoryContainer) motorMemory).setI("Test1Activity - concluded",getActivation(),id);
+             System.out.println("Concluding "+id);
+             ((MemoryContainer) motorMemory).setI(id+" - concluded",getActivation(),id);
         }
 
 	@Override
@@ -39,13 +39,13 @@ public class Test1ActivityCodelet extends ActivityCodelet {
 			return;
 		}
 		
-		motorMemory.setI(null);
+		((MemoryContainer) motorMemory).setI(null,0.0,id);
 		
 		for(Memory memory: perceptualMemories) {			
 			if(memory.getI()!=null && memory.getI() instanceof String) {
 				String perceptualContent = (String) memory.getI();
 				
-				((MemoryContainer) motorMemory).setI("Test1Activity - "+perceptualContent,getActivation(),id);
+				((MemoryContainer) motorMemory).setI(id+" - "+perceptualContent,getActivation(),id);
 			}
 		}
 	}

--- a/src/test/java/br/unicamp/meca/mind/action/Test1ActivityCodelet.java
+++ b/src/test/java/br/unicamp/meca/mind/action/Test1ActivityCodelet.java
@@ -26,6 +26,12 @@ public class Test1ActivityCodelet extends ActivityCodelet {
 			ArrayList<String> motivationalCodeletsIds, String motorCodeletId, String soarCodeletId) {
 		super(id, perceptualCodeletsIds, motivationalCodeletsIds, motorCodeletId, soarCodeletId);
 	}
+        
+        @Override
+	public void doConclusion(ArrayList<Memory> perceptualMemories, Memory broadcastMemory, Memory motorMemory) {
+             System.out.println("Concluding Test1Activity");
+             ((MemoryContainer) motorMemory).setI("Test1Activity - concluded",getActivation(),id);
+        }
 
 	@Override
 	public void proc(ArrayList<Memory> perceptualMemories, Memory broadcastMemory, Memory motorMemory) {

--- a/src/test/java/br/unicamp/meca/mind/action/Test2ActivityCodelet.java
+++ b/src/test/java/br/unicamp/meca/mind/action/Test2ActivityCodelet.java
@@ -38,7 +38,7 @@ public class Test2ActivityCodelet extends ActivityCodelet {
 			return;
 		}
 				
-		motorMemory.setI(null);
+		((MemoryContainer) motorMemory).setI(null,0.0,id);
 		
 		for(Memory memory: perceptualMemories) {			
 			if(memory.getI()!=null && memory.getI() instanceof String) {

--- a/src/test/java/br/unicamp/meca/mind/action/Test2ActivityCodelet.java
+++ b/src/test/java/br/unicamp/meca/mind/action/Test2ActivityCodelet.java
@@ -26,6 +26,11 @@ public class Test2ActivityCodelet extends ActivityCodelet {
 			ArrayList<String> motivationalCodeletsIds, String motorCodeletId, String soarCodeletId) {
 		super(id, perceptualCodeletsIds, motivationalCodeletsIds, motorCodeletId, soarCodeletId);		
 	}
+        
+        @Override
+	public void doConclusion(ArrayList<Memory> perceptualMemories, Memory broadcastMemory, Memory motorMemory) {
+            System.out.println("Concluding Test2Activity");
+        }
 
 	@Override
 	public void proc(ArrayList<Memory> perceptualMemories, Memory broadcastMemory, Memory motorMemory) {

--- a/src/test/java/br/unicamp/meca/mind/action/Test3ActivityCodelet.java
+++ b/src/test/java/br/unicamp/meca/mind/action/Test3ActivityCodelet.java
@@ -38,7 +38,7 @@ public class Test3ActivityCodelet extends ActivityCodelet {
 			return;
 		}
 		
-		motorMemory.setI(null);
+		((MemoryContainer) motorMemory).setI(null,0.0,id);
 		
 		for(Memory memory: perceptualMemories) {			
 			if(memory.getI()!=null && memory.getI() instanceof String) {

--- a/src/test/java/br/unicamp/meca/mind/action/Test3ActivityCodelet.java
+++ b/src/test/java/br/unicamp/meca/mind/action/Test3ActivityCodelet.java
@@ -26,6 +26,11 @@ public class Test3ActivityCodelet extends ActivityCodelet {
 			ArrayList<String> motivationalCodeletsIds, String motorCodeletId, String soarCodeletId) {
 		super(id, perceptualCodeletsIds, motivationalCodeletsIds, motorCodeletId, soarCodeletId);
 	}
+        
+        @Override
+	public void doConclusion(ArrayList<Memory> perceptualMemories, Memory broadcastMemory, Memory motorMemory) {
+            System.out.println("Concluding Test3Activity");
+        }
 
 	@Override
 	public void proc(ArrayList<Memory> perceptualMemories, Memory broadcastMemory, Memory motorMemory) {

--- a/src/test/java/br/unicamp/meca/mind/action/TestActivityCodelet.java
+++ b/src/test/java/br/unicamp/meca/mind/action/TestActivityCodelet.java
@@ -1,0 +1,152 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package br.unicamp.meca.mind.action;
+
+import br.unicamp.cst.core.entities.MemoryContainer;
+import br.unicamp.cst.core.entities.MemoryObject;
+import br.unicamp.meca.mind.MecaMind;
+import br.unicamp.meca.mind.motor.TestMotorCodelet;
+import br.unicamp.meca.mind.perceptual.TestPerceptualCodelet;
+import br.unicamp.meca.mind.sensory.TestPerceptionSensoryCodelet;
+import br.unicamp.meca.models.ActionSequencePlan;
+import br.unicamp.meca.models.ActionStep;
+import br.unicamp.meca.models.ActionStepTest;
+import br.unicamp.meca.system1.codelets.ActivityCodelet;
+import br.unicamp.meca.system1.codelets.MotorCodelet;
+import br.unicamp.meca.system1.codelets.PerceptualCodelet;
+import br.unicamp.meca.system1.codelets.SensoryCodelet;
+import java.util.ArrayList;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ *
+ * @author rgudwin
+ */
+public class TestActivityCodelet {
+    
+    SensoryCodelet sc;
+    PerceptualCodelet pc;
+    ActivityCodelet ac;
+    
+    @Test
+    public void testAccessMemoryObjects() {
+        ArrayList<String> lsc = new ArrayList();
+        lsc.add("m1");
+        lsc.add("m2");
+        lsc.add("m3");
+        ac = new Test1ActivityCodelet("teste",lsc,lsc,null,null);
+        ac.accessMemoryObjects();
+        assertEquals(ac.getPerceptionMemories().size(),0);
+        MemoryObject mo = new MemoryObject();
+        mo.setType("m1");
+        ac.addInput(mo);
+        mo = new MemoryObject();
+        mo.setType("m2");
+        ac.addInput(mo);
+        mo = new MemoryObject();
+        mo.setType("m3");
+        ac.addInput(mo);
+        ac.accessMemoryObjects();
+        assertEquals(ac.getPerceptionMemories().size(),3);
+        mo = new MemoryObject();
+        mo.setType("m1Drive");
+        ac.addInput(mo);
+        mo = new MemoryObject();
+        mo.setType("m2Drive");
+        ac.addInput(mo);
+        mo = new MemoryObject();
+        mo.setType("m3Drive");
+        ac.addInput(mo);
+        ac.accessMemoryObjects();
+        assertEquals(ac.getDriveMemories().size(),3);
+        ac = new Test1ActivityCodelet("teste",null,null,"motor","soar");
+        mo = new MemoryObject();
+        mo.setType("motor");
+        ac.addOutput(mo);
+        ac.accessMemoryObjects();
+        assertEquals(ac.getMotorMemory(),mo);
+        mo = new MemoryObject();
+        mo.setType("soar");
+        ac.addBroadcast(mo);
+        ac.accessMemoryObjects();
+        assertEquals(ac.getBroadcastMemory(),mo);
+        MemoryContainer mc = new MemoryContainer();
+        mc.setType(MecaMind.ACTION_SEQUENCE_PLAN_ID);
+        ac.addInput(mc);
+        ac.accessMemoryObjects();
+        assertEquals(ac.getActionSequencePlanMemoryContainer(),mc);
+    }
+
+    @Test
+    public void testActivityCodelet() {
+        sc = new TestPerceptionSensoryCodelet("sensory");
+        ArrayList<String> lsc = new ArrayList();
+        lsc.add("sensory");
+        pc = new TestPerceptualCodelet("perception",lsc);
+        lsc = new ArrayList();
+        ac =  new Test1ActivityCodelet("teste",null,null,null,null);
+        ac.accessMemoryObjects();
+        ac.proc();
+        ac.calculateActivation();
+        
+        ac = new Test1ActivityCodelet("teste",lsc,lsc,null,null);
+        ac.accessMemoryObjects();
+        ac.proc();
+        ac.calculateActivation();
+        
+        ac = new Test1ActivityCodelet("teste",lsc,lsc,"motor",null);
+        ac.accessMemoryObjects();
+        ac.proc();
+        ac.calculateActivation();
+        
+        MotorCodelet mc = new TestMotorCodelet("motor");
+        ac.accessMemoryObjects();
+        ac.proc();
+        ac.calculateActivation();
+           
+    }
+    
+    @Test
+    public void testCalculateActivation() {
+        ArrayList<String> lsc = new ArrayList();
+        lsc.add("m1");
+        lsc.add("m2");
+        lsc.add("m3");
+        ac = new Test1ActivityCodelet("teste",null,lsc,null,null);
+        MemoryObject mo = new MemoryObject();
+        mo.setType("m1Drive");
+        mo.setEvaluation(0.5);
+        ac.addInput(mo);
+        mo = new MemoryObject();
+        mo.setType("m2Drive");
+        mo.setEvaluation(0.6);
+        ac.addInput(mo);
+        mo = new MemoryObject();
+        mo.setType("m3Drive");
+        ac.addInput(mo);
+        mo.setEvaluation(0.8);
+        ac.accessMemoryObjects();
+        ac.calculateActivation();
+        double presumedActivation = (0.5+0.6+0.8)/3;
+        assertEquals(ac.getActivation(),presumedActivation,0);
+        MemoryContainer mc = new MemoryContainer();
+        mc.setType(MecaMind.ACTION_SEQUENCE_PLAN_ID);
+        ActionStep as[] = new ActionStep[1];
+        ActionSequencePlan asp = new ActionSequencePlan(as);
+        mc.setI(asp,0.2);
+        ac.addInput(mc);
+        ac.accessMemoryObjects();
+        ac.calculateActivation();
+        // Because the ActionStep is null, the evaluation is 0
+        assertEquals(ac.getActivation(),0,0);
+        as[0] = new ActionStepTest("teste");
+        // Now that there is an action step with the same name as the ActivityCodelet, it should be 0.2
+        ac.calculateActivation();
+        assertEquals(ac.getActivation(),0.2,0);
+    }
+    
+}

--- a/src/test/java/br/unicamp/meca/mind/tracking/testActivityTrackingCodelet.java
+++ b/src/test/java/br/unicamp/meca/mind/tracking/testActivityTrackingCodelet.java
@@ -1,0 +1,115 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package br.unicamp.meca.mind.tracking;
+
+import br.unicamp.cst.core.entities.MemoryContainer;
+import br.unicamp.cst.core.entities.MemoryObject;
+import br.unicamp.meca.mind.MecaMind;
+import br.unicamp.meca.models.ActionSequencePlan;
+import br.unicamp.meca.models.ActionStep;
+import br.unicamp.meca.models.ActionStepTest;
+import br.unicamp.meca.system1.codelets.ActivityTrackingCodelet;
+import java.util.ArrayList;
+import java.util.List;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ *
+ * @author rgudwin
+ */
+public class testActivityTrackingCodelet {
+    ActivityTrackingCodelet atc;
+    
+    @Test
+    public void testActivityTrackingCodelet() {
+        atc = new ActivityTrackingCodelet("tracking",null);
+        atc.accessMemoryObjects();
+        atc.calculateActivation();
+        // This tests the case when there is still no sequence plan to be tracked
+        atc.proc();
+        // Now let's introduce an empty perception list
+        ArrayList<String> lop = new ArrayList();
+        atc = new ActivityTrackingCodelet("tracking",lop);
+        atc.accessMemoryObjects();
+        atc.calculateActivation();
+        atc.proc();
+        // Now let's define an inexistent perception
+        lop.add("perception");
+        atc.accessMemoryObjects();
+        atc.calculateActivation();
+        atc.proc();
+        // Now, still without perception, let's introduce a sequence plan
+        MemoryContainer mc = new MemoryContainer();
+        mc.setType(MecaMind.ACTION_SEQUENCE_PLAN_ID);
+        atc.addInput(mc);
+        atc.accessMemoryObjects();
+        // Now there is a memory object, but still no sequence plan
+        atc.accessMemoryObjects();
+        atc.calculateActivation();
+        atc.proc();
+        // Now let's include a plan, but still without any action step
+        ActionStep as[] = new ActionStep[3];
+        ActionSequencePlan asp = new ActionSequencePlan(as);
+        mc.setI(asp,0.2);
+        atc.accessMemoryObjects();
+        atc.calculateActivation();
+        atc.proc();
+        // Finally, let's include the action steps
+        ActionStep as1 = new ActionStepTest("tracking");
+        as[0] = as1;
+        ActionStep as2 = new ActionStepTest("tracking");
+        as[1] = as2;
+        ActionStep as3 = new ActionStepTest("tracking");
+        as[2] = as3;
+        atc.accessMemoryObjects();
+        atc.calculateActivation();
+        atc.proc();
+        assertEquals(asp.getCurrentActionIdIndex(),0);
+        // Now let's introduce a Perception Memory to track
+        // And now finally let's provide an existent perception, still without info
+        MemoryObject per = new MemoryObject();
+        per.setType("perception");
+        atc = new ActivityTrackingCodelet("tracking",lop);
+        atc.addInput(per);
+        atc.addInput(mc);
+        atc.accessMemoryObjects();
+        atc.calculateActivation();
+        atc.proc();
+        assertEquals(asp.getCurrentActionIdIndex(),0);
+        // Now, let's create the conditions for the codelet decide to move to its 2nd step
+        per.setEvaluation(1.0);
+        atc.addInput(per);
+        //as[0].needsConclusion = true;
+        atc.accessMemoryObjects();
+        atc.calculateActivation();
+        assertEquals(as[0].executed,false);
+        atc.proc();
+        // Now, because there are conditions for move to the second step of the plan, the index should be 1
+        assertEquals(as[0].executed,true);
+        // Because the ActionStep 0 was executed, now it needs conclusion
+        assertEquals(as[0].needsConclusion,true);
+        assertEquals(asp.getCurrentActionIdIndex(),1);
+        assertEquals(as[1].executed,false);
+        atc.proc();
+        // Now let's play a little ... because the conclusion didn't come, this proc will not move to the 3rd action step
+        assertEquals(as[1].executed,false);
+        // Let's then conclude the action step 0 e see what happens
+        as[0].needsConclusion = false;
+        atc.proc();
+        // Now, this allows the execution of action step 1
+        assertEquals(as[1].executed,true);
+        assertEquals(asp.getCurrentActionIdIndex(),2);
+        assertEquals(as[2].executed,false);
+        assertEquals(as[1].needsConclusion,true);
+        as[1].needsConclusion = false;
+        atc.proc();
+        assertEquals(as[2].needsConclusion,true);
+        assertEquals(asp.getCurrentActionIdIndex(),0);
+        assertEquals(as[2].executed,true);
+    }
+    
+}

--- a/src/test/java/br/unicamp/meca/mind/tracking/testActivityTrackingCodelet.java
+++ b/src/test/java/br/unicamp/meca/mind/tracking/testActivityTrackingCodelet.java
@@ -8,12 +8,13 @@ package br.unicamp.meca.mind.tracking;
 import br.unicamp.cst.core.entities.MemoryContainer;
 import br.unicamp.cst.core.entities.MemoryObject;
 import br.unicamp.meca.mind.MecaMind;
+import br.unicamp.meca.mind.action.Test1ActivityCodelet;
 import br.unicamp.meca.models.ActionSequencePlan;
 import br.unicamp.meca.models.ActionStep;
 import br.unicamp.meca.models.ActionStepTest;
+import br.unicamp.meca.system1.codelets.ActivityCodelet;
 import br.unicamp.meca.system1.codelets.ActivityTrackingCodelet;
 import java.util.ArrayList;
-import java.util.List;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
@@ -23,6 +24,8 @@ import org.junit.Test;
  */
 public class testActivityTrackingCodelet {
     ActivityTrackingCodelet atc;
+    ActivityCodelet actc1;
+    ActivityCodelet actc2;
     
     @Test
     public void testActivityTrackingCodelet() {
@@ -111,5 +114,78 @@ public class testActivityTrackingCodelet {
         assertEquals(asp.getCurrentActionIdIndex(),0);
         assertEquals(as[2].executed,true);
     }
+    
+    @Test 
+    public void testDoConclusion() {
+        // Creation of the Perception Memory
+        ArrayList<String> lop = new ArrayList();
+        MemoryObject per = new MemoryObject();
+        per.setType("perception");
+        per.setI("perception");
+        lop.add("perception");
+        atc = new ActivityTrackingCodelet("tracking",lop);
+        atc.addInput(per);
+        // Creation of the ActionSequencePlan
+        MemoryContainer planContainer = new MemoryContainer();
+        planContainer.setType(MecaMind.ACTION_SEQUENCE_PLAN_ID);
+        ActionStep as1 = new ActionStepTest("activity1");
+        ActionStep as2 = new ActionStepTest("activity2");
+        ActionSequencePlan asp = new ActionSequencePlan(new ActionStep[] {as1,as2});
+        planContainer.setI(asp,0.2,"plan");
+        atc.addInput(planContainer);
+        // Creation of the MotorMemory
+        MemoryContainer motorMemory = new MemoryContainer();
+        motorMemory.setType("motor");
+        // Now creating the ActivityCodelets which will serve the ActionStep
+        actc1 = new Test1ActivityCodelet("activity1",lop,null,"motor",null);
+        actc1.addInput(per);
+        actc1.addInput(planContainer);
+        actc1.addOutput(motorMemory);
+        actc2 = new Test1ActivityCodelet("activity2",lop,null,"motor",null);
+        actc2.addInput(per);
+        actc2.addInput(planContainer);
+        actc2.addOutput(motorMemory);
+        // Execute the 1st time step
+        step();
+        // Verifying if the activity1 modified the motor codelet
+        assertEquals(motorMemory.getI(),"activity1 - perception");
+        // now let's cause the ActivityTrackingCodelet to conclude step 1 and move to step 2
+        per.setEvaluation(1.0);
+        // And change the activation to a lower value than activity1 ... 
+        // if activity1 is not concluded by doConclusion, it will stay at the motor codelet and ruin the output of motorCodelet
+        planContainer.setI(asp,0.1,"plan");
+        step();
+        // Let's first verify if the plan was advanced to step 2
+        assertEquals(asp.getCurrentActionIdIndex(),1);
+        // Let's verify if activity2 modified the motor codelet
+        assertEquals(motorMemory.getI(),"activity2 - perception");
+        // Let's verify if activity1 was concluded
+        assertEquals(motorMemory.getI(0),"activity1 - concluded");
+        // Now let's do one more step to conclude the plan 
+        step();
+        // And verify the plan is back to step 1 and executed
+        assertEquals(asp.getCurrentActionIdIndex(),0);
+        assertEquals(asp.getCurrentActionStep().executed,true);
+        assertEquals(asp.getLastExecutedActionStep().executed,true);
+        // Let's do a final step and check if everything remains the same
+        step();
+        assertEquals(asp.getCurrentActionIdIndex(),0);
+        assertEquals(asp.getCurrentActionStep().executed,true);
+        assertEquals(asp.getLastExecutedActionStep().executed,true);
+        
+    }
+    
+    private void step() {
+        atc.accessMemoryObjects();
+        atc.calculateActivation();
+        atc.proc();
+        actc1.accessMemoryObjects();
+        actc1.calculateActivation();
+        actc1.proc();
+        actc2.accessMemoryObjects();
+        actc2.calculateActivation();
+        actc2.proc();
+    }
+            
     
 }

--- a/src/test/java/br/unicamp/meca/models/ActionSequencePlanTest.java
+++ b/src/test/java/br/unicamp/meca/models/ActionSequencePlanTest.java
@@ -12,22 +12,91 @@ import org.junit.Test;
  *
  */
 public class ActionSequencePlanTest {
+    
+    ActionStep as1 = new ActionStepTest("Land");
+    ActionStep as2 = new ActionStepTest("Stop");
+    ActionSequencePlan landAndStopSequencePlan = new ActionSequencePlan(new ActionStep[] {as1,as2});
 	
     public void setUp() {
         System.out.println("########## Action Sequence Plan TESTS ##########");
     }
+    
+    @Test
+    public void testGetCurrentActionIdIndex() {
+        landAndStopSequencePlan.setCurrentActionIdIndex(0);
+        int currentStep = landAndStopSequencePlan.getCurrentActionIdIndex();
+        assertEquals(currentStep,0);
+        landAndStopSequencePlan.setCurrentActionIdIndex(1);
+        currentStep = landAndStopSequencePlan.getCurrentActionIdIndex();
+        assertEquals(currentStep,1);
+    }
 
     @Test
     public void testGetCurrentActionId() {
-    	
-    	ActionStep as1 = new ActionStepTest("Land");
-        ActionStep as2 = new ActionStepTest("Stop");
-        ActionSequencePlan landAndStopSequencePlan = new ActionSequencePlan(new ActionStep[] {as1,as2});
-    	
+        landAndStopSequencePlan.setCurrentActionIdIndex(0);                
     	assertEquals(landAndStopSequencePlan.getCurrentActionStep().getActionId(), "Land");
-    	
+        
     	landAndStopSequencePlan.setCurrentActionIdIndex(1);
-    	
     	assertEquals(landAndStopSequencePlan.getCurrentActionStep().getActionId(), "Stop");
+    }
+    
+    @Test
+    public void testGetCurrentActionStep() {
+        landAndStopSequencePlan.setCurrentActionIdIndex(0);
+        ActionStep as = landAndStopSequencePlan.getCurrentActionStep();
+        assertEquals(as,as1);
+        landAndStopSequencePlan.setCurrentActionIdIndex(1);
+        as = landAndStopSequencePlan.getCurrentActionStep();
+        assertEquals(as,as2);
+    }
+    
+    @Test
+    public void testLastActionStep() {
+        landAndStopSequencePlan.setCurrentActionIdIndex(0);
+        ActionStep lastAS = landAndStopSequencePlan.getLastActionStep();
+        assertEquals(lastAS,as2);
+        assertEquals(lastAS.executed,false);
+        assertEquals(lastAS.needsConclusion,false);
+        
+        landAndStopSequencePlan.setCurrentActionIdIndex(1);
+        lastAS = landAndStopSequencePlan.getLastActionStep();
+        assertEquals(lastAS,as1);
+        assertEquals(lastAS.executed,false);
+        assertEquals(lastAS.needsConclusion,false);
+    }
+    
+    @Test
+    public void testGoToNextAction() {
+        landAndStopSequencePlan.setCurrentActionIdIndex(0);
+        ActionStep as = landAndStopSequencePlan.getCurrentActionStep();
+        assertEquals(as,as1);
+        assertEquals(as1.executed,false);
+        
+        landAndStopSequencePlan.gotoNextAction();
+        as = landAndStopSequencePlan.getCurrentActionStep();
+        assertEquals(as,as2);
+        assertEquals(as1.executed,true);
+        assertEquals(as2.executed,false);
+        landAndStopSequencePlan.gotoNextAction();
+        as = landAndStopSequencePlan.getCurrentActionStep();
+        assertEquals(as,as1);
+        assertEquals(as2.executed,true);
+    }
+    
+    @Test 
+    public void testResetPlan() {
+        as1.executed = true;
+        as2.executed = true;
+        landAndStopSequencePlan.resetPlan();
+        for (ActionStep ass : landAndStopSequencePlan.getActionStepSequence()) {
+            assertEquals(ass.executed,false);
+            assertEquals(ass.needsConclusion,false);
+        }
+    }
+    
+    @Test
+    public void testToString() {
+       String s = landAndStopSequencePlan.toString();
+       assertEquals(s,"{Land, Stop}");
     }
 }

--- a/src/test/java/br/unicamp/meca/models/ActionSequencePlanTest.java
+++ b/src/test/java/br/unicamp/meca/models/ActionSequencePlanTest.java
@@ -53,13 +53,13 @@ public class ActionSequencePlanTest {
     @Test
     public void testLastActionStep() {
         landAndStopSequencePlan.setCurrentActionIdIndex(0);
-        ActionStep lastAS = landAndStopSequencePlan.getLastActionStep();
+        ActionStep lastAS = landAndStopSequencePlan.getLastExecutedActionStep();
         assertEquals(lastAS,as2);
         assertEquals(lastAS.executed,false);
         assertEquals(lastAS.needsConclusion,false);
         
         landAndStopSequencePlan.setCurrentActionIdIndex(1);
-        lastAS = landAndStopSequencePlan.getLastActionStep();
+        lastAS = landAndStopSequencePlan.getLastExecutedActionStep();
         assertEquals(lastAS,as1);
         assertEquals(lastAS.executed,false);
         assertEquals(lastAS.needsConclusion,false);

--- a/src/test/java/br/unicamp/meca/models/ActionStepTest.java
+++ b/src/test/java/br/unicamp/meca/models/ActionStepTest.java
@@ -25,6 +25,11 @@ public class ActionStepTest extends ActionStep {
      
     @Override 
     public boolean stopCondition(List<Memory> perceptions) {
+        if (perceptions != null && perceptions.size() > 0) {
+            Memory perceptionMemory = perceptions.get(0);
+            if (perceptionMemory != null && perceptionMemory.getEvaluation() > 0.5) return(true);
+            else return(false);
+        }
         return(false);
     }
     

--- a/src/test/java/br/unicamp/meca/models/ActionStepTester.java
+++ b/src/test/java/br/unicamp/meca/models/ActionStepTester.java
@@ -4,8 +4,6 @@
  * and open the template in the editor.
  */
 package br.unicamp.meca.models;
-import br.unicamp.cst.core.entities.Memory;
-import java.util.List;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 


### PR DESCRIPTION
(and also ActionSequencePlan and ActionStep) to include a way for executed ActionSteps to conclude the plan, after the ActivityTrackingCodelet has advanced to the following ActionStep. This is necessary, usually, to set the MotorCodelet to null, after the ActionStep was concluded.

### Why was it necessary?

In MECA 0.4.2,  when an ActionSequencePlan is advanced by ActivityTrackingCodelet, the advance to a new step does not allow the conclusion of the old step, usually setting the MotorCodelet to null. This leads to an erroneous behavior, where the MotorCodelet still holds traces of the old step, which is not necessary anymore. In this new code, as soon as the ActivityTrackingCodelet advances to a new ActionStep, it marks the old ActionStep as in need of a conclusion. Then, the ActivityCodelet can detect this situation e provide the finalization of the old step.  

### How was it done?

We include two flags in the ActionStep: executed and needsConclusion. As soon as the ActivityTrackingCodelet advances to a new ActionStep, it sets the executed and needsConclusion flags to true. With this aid, the ActivityCodelet can detect this situation, and call a new doConclusion() procedure, which provides this finalization, allowing the cleaning of a finished ActionStep. 

### Implementation details

We created a new abstract method doConclusion which every ActivityCodelet will have to implement, in order to provide this cleaning code. This method is called just once, after que ActivityTrackingCodelet advances to a new ActionStep. The main changes were on ActivityTrackingCodelet, ActivityCodelet, ActionStep and ActionSequencePlan, in order to implement this new mechanism for finalization. 


### How to test?

New tests were included in the Testing code in order to test all these new functionalities. 

### Future works

No further development is necessary for this issue. 
