### PR TITLE
Activity codelet

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Note: This library is still under development, and some concepts or features mig
 ```
 	dependencies {
             ...
-            implementation 'com.github.CST-Group:meca:0.4.3'
+            implementation 'com.github.CST-Group:meca:0.4.4'
 	}
 ```
 
@@ -53,7 +53,7 @@ Sometimes, the version number (tag) in this README gets out of date, as maintain
 	<dependency>
 	    <groupId>com.github.CST-Group</groupId>
 	    <artifactId>meca</artifactId>
-	    <version>0.4.2</version>
+	    <version>0.4.4</version>
 	</dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ description = "The Multipurpose Enhanced Cognitive Architecture (MECA)"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
-version = '0.4.3'
+version = '0.4.4'
 
 repositories {
     mavenCentral()

--- a/src/main/java/br/unicamp/meca/system1/codelets/ActivityCodelet.java
+++ b/src/main/java/br/unicamp/meca/system1/codelets/ActivityCodelet.java
@@ -168,23 +168,27 @@ public abstract class ActivityCodelet extends Codelet {
 
 	@Override
 	public void proc() {		
+                // This is the case when this ActivityCodelet is following a plan - there is a plan available
 		if(actionSequencePlanMemoryContainer != null && actionSequencePlanMemoryContainer.getI() != null && actionSequencePlanMemoryContainer.getI() instanceof ActionSequencePlan) {
 			ActionSequencePlan actionSequencePlan = (ActionSequencePlan) actionSequencePlanMemoryContainer.getI();
 			ActionStep currentAction = actionSequencePlan.getCurrentActionStep();
-                        String currentActionId = currentAction.getActionId();
-
-			if(currentActionId != null && currentActionId.equalsIgnoreCase(id) && currentAction.executed == false) {
-				proc(perceptualMemories, broadcastMemory, motorMemory);
-			}
-                        else {
-                            ActionStep lastActionStep = actionSequencePlan.getLastExecutedActionStep();
-                            String lastActionId = lastActionStep.getActionId();
-                            if (lastActionStep != null && lastActionStep.needsConclusion && lastActionId.equalsIgnoreCase(id)) {
+                        ActionStep lastActionStep = actionSequencePlan.getLastExecutedActionStep();
+                        String lastActionId;
+                        if (lastActionStep != null) {
+                            lastActionId = lastActionStep.getActionId();
+                            if (lastActionId != null && lastActionId.equalsIgnoreCase(id) && lastActionStep.needsConclusion) {
                                 doConclusion(perceptualMemories, broadcastMemory, motorMemory);
                                 lastActionStep.needsConclusion = false;
                             }
                         }
-		}else {
+                        String currentActionId;
+                        if (currentAction != null) {
+                            currentActionId = currentAction.getActionId();
+                            if(currentActionId != null && currentActionId.equalsIgnoreCase(id) && currentAction.executed == false) {
+				proc(perceptualMemories, broadcastMemory, motorMemory);
+                            }
+                        }
+		}else { // This is the case when there is NO plan available, and the ActivityCodelet should be run only with Perception
 			proc(perceptualMemories, broadcastMemory, motorMemory);
 		}
 	}


### PR DESCRIPTION
### Why was it necessary?

In the specific case where an ActionSequencePlan has two successive ActionSteps which should be treated by the same ActivityCodelet, the plan execution was entering in a deadlock. This was caused by the fact that the code responsible for treating the doConclusion was called in an exclusive mode, i.e., only when the currentActionStep was different from the lastExecutedActionStep. It worked well for all the cases where there were no successive ActionSteps of the same type, but failed if that happened, causing a deadlock. 

### How was it done?

The current PR changed the situations in which doConclusion is called. It is not being called exclusively, as in the previous version, but now the proc() method first check if there is the necessity of calling doConclusion, before calling the proc(args) method. In the current implementation, if both the currentActionStep and the lastExecutedActionStep are of the same type, the ActivityCodelet treating both of them first perform the doConclusion (to treat the lastExecutedActionStep need for conclusion) and later executes the proc(args). This avoids the deadlock. 

### Implementation details

The main proc() function in the ActivityCodelet class was changed to implement this new strategy. 

### How to test?

A new test testTwoActionStepsOfSameType was created within testActivityTrackingCodelet to test this particular situation. 

### Future works

No necessary further work to solve this issue
