### PR TITLE
Generalizing the SoarCodelet as a PlanningCodelet

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Note: This library is still under development, and some concepts or features mig
 ```
 	dependencies {
             ...
-            implementation 'com.github.CST-Group:meca:0.4.4'
+            implementation 'com.github.CST-Group:meca:0.5.0'
 	}
 ```
 
@@ -53,7 +53,7 @@ Sometimes, the version number (tag) in this README gets out of date, as maintain
 	<dependency>
 	    <groupId>com.github.CST-Group</groupId>
 	    <artifactId>meca</artifactId>
-	    <version>0.4.4</version>
+	    <version>0.5.0</version>
 	</dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ description = "The Multipurpose Enhanced Cognitive Architecture (MECA)"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
-version = '0.4.4'
+version = '0.5.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/br/unicamp/meca/mind/MecaMind.java
+++ b/src/main/java/br/unicamp/meca/mind/MecaMind.java
@@ -874,4 +874,11 @@ public class MecaMind extends Mind {
 	public void setActivityCodelets(List<ActivityCodelet> activityCodelets) {
 		this.activityCodelets = activityCodelets;
 	}
+
+	/**
+	 * @param planningCodelet the planningCodelet to set
+	 */
+	public void setPlanningCodelet(IPlanningCodelet planningCodelet) {
+		this.planningCodelet = planningCodelet;
+	}
 }

--- a/src/main/java/br/unicamp/meca/mind/MecaMind.java
+++ b/src/main/java/br/unicamp/meca/mind/MecaMind.java
@@ -14,6 +14,7 @@ package br.unicamp.meca.mind;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -41,8 +42,8 @@ import br.unicamp.meca.system2.codelets.EpisodicLearningCodelet;
 import br.unicamp.meca.system2.codelets.EpisodicRetrievalCodelet;
 import br.unicamp.meca.system2.codelets.ExpectationCodelet;
 import br.unicamp.meca.system2.codelets.GoalCodelet;
+import br.unicamp.meca.system2.codelets.IPlanningCodelet;
 import br.unicamp.meca.system2.codelets.SoarCodelet;
-import java.util.Iterator;
 
 /**
  * This class represents the MECA's agent mind.This is the main class to be used
@@ -74,7 +75,7 @@ public class MecaMind extends Mind {
 	private Memory actionSequencePlanMemoryContainer;
 	private Memory actionSequencePlanRequestMemoryContainer;
 	private ActivityTrackingCodelet activityTrackingCodelet;
-        private static HashMap<String,String> memoryGroups = new HashMap();
+    private static HashMap<String,String> memoryGroups = new HashMap();
 
 	/*
 	 * System 2
@@ -85,7 +86,7 @@ public class MecaMind extends Mind {
 	private EpisodicRetrievalCodelet episodicRetrievalCodelet;
 	private ExpectationCodelet expectationCodelet;
 	private ConsciousnessCodelet consciousnessCodelet;
-	private SoarCodelet soarCodelet;
+	private IPlanningCodelet planningCodelet;
 	private GoalCodelet goalCodelet;
 	private AppraisalCodelet appraisalCodelet;
 	private WorkingMemory workingMemory;
@@ -150,7 +151,7 @@ public class MecaMind extends Mind {
 		mountMotorCodelets();
 		mountAttentionCodelets();
 		mountWorkingMemory();
-		mountSoarCodelet();		
+		mountPlanningCodelet();		
 		mountMotivationalCodelets();
 		mountActionSequencePlanMemory();
 		mountBehaviorCodelets();
@@ -176,8 +177,8 @@ public class MecaMind extends Mind {
         }
 
 	private void mountModules() {
-		if (getSoarCodelet() != null) {
-			getPlansSubsystemModule().setjSoarCodelet(getSoarCodelet());
+		if (getPlanningCodelet() != null && getPlanningCodelet() instanceof SoarCodelet) {
+			getPlansSubsystemModule().setjSoarCodelet((SoarCodelet) getPlanningCodelet());
 		}
 	}
 
@@ -353,9 +354,9 @@ public class MecaMind extends Mind {
 							}
 						}
 					}
-					if (soarCodelet != null && soarCodelet.getId() != null && behaviorCodelet.getSoarCodeletId() != null) {
-						if (soarCodelet.getId().equalsIgnoreCase(behaviorCodelet.getSoarCodeletId())) {
-							behaviorCodelet.addBroadcasts(soarCodelet.getOutputs());
+					if (planningCodelet != null && planningCodelet.getId() != null && behaviorCodelet.getPlanningCodeletId() != null) {
+						if (planningCodelet.getId().equalsIgnoreCase(behaviorCodelet.getPlanningCodeletId())) {
+							behaviorCodelet.addBroadcasts(planningCodelet.getOutputs());
 						}
 					}
 					insertCodelet(behaviorCodelet);
@@ -415,9 +416,9 @@ public class MecaMind extends Mind {
 							}
 						}
 					}
-					if (soarCodelet != null && soarCodelet.getId() != null && activityCodelet.getSoarCodeletId() != null) {
-						if (soarCodelet.getId().equalsIgnoreCase(activityCodelet.getSoarCodeletId())) {
-							activityCodelet.addBroadcasts(soarCodelet.getOutputs());
+					if (planningCodelet != null && planningCodelet.getId() != null && activityCodelet.getPlanningCodeletId() != null) {
+						if (planningCodelet.getId().equalsIgnoreCase(activityCodelet.getPlanningCodeletId())) {
+							activityCodelet.addBroadcasts(planningCodelet.getOutputs());
 						}
 					}
 					activityCodelet.addInput(actionSequencePlanMemoryContainer);
@@ -465,11 +466,11 @@ public class MecaMind extends Mind {
 		}
 	}
 
-	private void mountSoarCodelet() {
-		if (soarCodelet != null) {
-			soarCodelet.addInput(createMemoryObject(WorkingMemory.WORKING_MEMORY_INPUT, getWorkingMemory()));
-			soarCodelet.addOutput(createMemoryObject(soarCodelet.getId()));
-			insertCodelet(soarCodelet);
+	private void mountPlanningCodelet() {
+		if (planningCodelet != null) {
+			planningCodelet.addInput(createMemoryObject(WorkingMemory.WORKING_MEMORY_INPUT, getWorkingMemory()));
+			planningCodelet.addOutput(createMemoryObject(planningCodelet.getId()));
+			insertCodelet((Codelet) planningCodelet);
 		}
 	}
 
@@ -612,11 +613,13 @@ public class MecaMind extends Mind {
 	/**
 	 * Sets the Soar Codelet.
 	 * 
+	 * @deprecated instead, add the SoarCodelet using the interface IPlanningCodelet
 	 * @param soarCodelet
 	 *            the soarCodelet to set
 	 */
+	@Deprecated
 	public void setSoarCodelet(SoarCodelet soarCodelet) {
-		this.soarCodelet = soarCodelet;
+		this.planningCodelet = soarCodelet;
 	}
 
 	/**
@@ -825,12 +828,12 @@ public class MecaMind extends Mind {
 	}
 
 	/**
-	 * Gets the Soar Codelet.
+	 * Gets the Planning Codelet.
 	 * 
-	 * @return the soarCodelet.
+	 * @return the planningCodelet.
 	 */
-	public SoarCodelet getSoarCodelet() {
-		return soarCodelet;
+	public IPlanningCodelet getPlanningCodelet() {
+		return planningCodelet;
 	}
 
 	/**

--- a/src/main/java/br/unicamp/meca/system1/codelets/ActivityCodelet.java
+++ b/src/main/java/br/unicamp/meca/system1/codelets/ActivityCodelet.java
@@ -39,7 +39,7 @@ public abstract class ActivityCodelet extends Codelet {
 	protected ArrayList<String> motivationalCodeletsIds;
 	protected ArrayList<Memory> driveMemories;
 
-	protected String soarCodeletId;
+	protected String planningCodeletId;
 	protected Memory broadcastMemory;
 	
 	protected Memory actionSequencePlanMemoryContainer;
@@ -63,8 +63,8 @@ public abstract class ActivityCodelet extends Codelet {
 	 * @param motorCodeletId
 	 *            the id of the Motor Codelet which will read the outputs of
 	 *            this Activity Codelet.
-	 * @param soarCodeletId
-	 *            the id of the Soar Codelet whose outputs will be read by this
+	 * @param planningCodeletId
+	 *            the id of the Planning Codelet whose outputs will be read by this
 	 *            Activity Codelet.
 	 */
 	public ActivityCodelet(
@@ -72,12 +72,12 @@ public abstract class ActivityCodelet extends Codelet {
 			ArrayList<String> perceptualCodeletsIds, 
 			ArrayList<String> motivationalCodeletsIds, 
 			String motorCodeletId,
-			String soarCodeletId) {
+			String planningCodeletId) {
 		setName(id);
 		this.id = id;
 		this.motorCodeletId = motorCodeletId;
 		this.perceptualCodeletsIds = perceptualCodeletsIds;
-		this.soarCodeletId = soarCodeletId;
+		this.planningCodeletId = planningCodeletId;
 		this.motivationalCodeletsIds = motivationalCodeletsIds;
 	}
 
@@ -115,7 +115,7 @@ public abstract class ActivityCodelet extends Codelet {
 		}
 		
 		if(broadcastMemory == null) {
-			broadcastMemory = this.getBroadcast(soarCodeletId, index);
+			broadcastMemory = this.getBroadcast(planningCodeletId, index);
 		}
 		
 
@@ -219,24 +219,24 @@ public abstract class ActivityCodelet extends Codelet {
 	public abstract void doConclusion(ArrayList<Memory> perceptualMemories, Memory broadcastMemory, Memory motorMemory);
 
 	/**
-	 * Returns the id of the Soar Codelet whose outputs will be read by this
+	 * Returns the id of the Planning Codelet whose outputs will be read by this
 	 * Activity Codelet.
 	 * 
-	 * @return the soarCodeletId
+	 * @return the planningCodeletId
 	 */
-	public String getSoarCodeletId() {
-		return soarCodeletId;
+	public String getPlanningCodeletId() {
+		return planningCodeletId;
 	}
 
 	/**
-	 * Sets the id of the Soar Codelet whose outputs will be read by this
+	 * Sets the id of the Planning Codelet whose outputs will be read by this
 	 * Activity Codelet.
 	 * 
-	 * @param soarCodeletId
-	 *            the soarCodeletId to set
+	 * @param planningCodeletId
+	 *            the planningCodeletId to set
 	 */
-	public void setSoarCodeletId(String soarCodeletId) {
-		this.soarCodeletId = soarCodeletId;
+	public void setPlanningCodeletId(String planningCodeletId) {
+		this.planningCodeletId = planningCodeletId;
 	}
 
 	/**

--- a/src/main/java/br/unicamp/meca/system1/codelets/BehaviorCodelet.java
+++ b/src/main/java/br/unicamp/meca/system1/codelets/BehaviorCodelet.java
@@ -46,7 +46,7 @@ public abstract class BehaviorCodelet extends Codelet {
 	protected ArrayList<String> motivationalCodeletsIds;
 	protected ArrayList<Memory> driveMemories;
 
-	protected String soarCodeletId;
+	protected String planningCodeletId;
 	protected Memory broadcastMemory;
 	
 	protected ActionSequencePlan actionSequencePlan;
@@ -67,19 +67,19 @@ public abstract class BehaviorCodelet extends Codelet {
 	 * @param motivationalCodeletsIds
 	 *            the list of ids of the Motivational Codelets whose outputs
 	 *            will be read by this Behavior Codelet.
-	 * @param soarCodeletId
-	 *            the id of the Soar Codelet whose outputs will be read by this
+	 * @param planningCodeletId
+	 *            the id of the Planning Codelet whose outputs will be read by this
 	 *            Behavior Codelet.
 	 * @see Codelet
 	 */
 	public BehaviorCodelet(String id, ArrayList<String> perceptualCodeletsIds, ArrayList<String> motivationalCodeletsIds,
-			String soarCodeletId) {
+			String planningCodeletId) {
 		super();
 		setName(id);
 		this.id = id;
 		this.perceptualCodeletsIds = perceptualCodeletsIds;
 		this.motivationalCodeletsIds = motivationalCodeletsIds;
-		this.soarCodeletId = soarCodeletId;
+		this.planningCodeletId = planningCodeletId;
 	}
 		
 	@Override
@@ -115,7 +115,7 @@ public abstract class BehaviorCodelet extends Codelet {
 		}
 		
 		if(broadcastMemory == null) {
-			broadcastMemory = this.getBroadcast(soarCodeletId, index);
+			broadcastMemory = this.getBroadcast(planningCodeletId, index);
 		}
 		
 		if(actionSequencePlanMemoryContainer == null)
@@ -184,24 +184,24 @@ public abstract class BehaviorCodelet extends Codelet {
 
 
 	/**
-	 * Returns the id of the Soar Codelet whose outputs will be read by this
+	 * Returns the id of the Planning Codelet whose outputs will be read by this
 	 * Behavior Codelet.
 	 * 
-	 * @return the soarCodeletId
+	 * @return the planningCodeletId
 	 */
-	public String getSoarCodeletId() {
-		return soarCodeletId;
+	public String getPlanningCodeletId() {
+		return planningCodeletId;
 	}
 
 	/**
-	 * Sets the id of the Soar Codelet whose outputs will be read by this
+	 * Sets the id of the Planning Codelet whose outputs will be read by this
 	 * Behavior Codelet.
 	 * 
-	 * @param soarCodeletId
-	 *            the soarCodeletId to set
+	 * @param planningCodeletId
+	 *            the planningCodeletId to set
 	 */
-	public void setSoarCodeletId(String soarCodeletId) {
-		this.soarCodeletId = soarCodeletId;
+	public void setPlanningCodeletId(String planningCodeletId) {
+		this.planningCodeletId = planningCodeletId;
 	}
 
 	/**

--- a/src/main/java/br/unicamp/meca/system2/codelets/IPlanningCodelet.java
+++ b/src/main/java/br/unicamp/meca/system2/codelets/IPlanningCodelet.java
@@ -1,0 +1,53 @@
+/**
+ * 
+ */
+package br.unicamp.meca.system2.codelets;
+
+import java.util.List;
+
+import br.unicamp.cst.core.entities.Memory;
+
+/**
+ * @author andre
+ *
+ */
+public interface IPlanningCodelet {
+	
+	/**
+	 * Returns the id of this Planning Codelet.
+	 * 
+	 * @return the id
+	 */
+	String getId();
+	
+	/**
+	 * Gets the list of output memories.
+	 * 
+	 * @return the outputs.
+	 */
+	List<Memory> getOutputs();
+	
+	/**
+	 * Add a memory to the output list.
+	 * 
+	 * @param memory
+	 *            one output to set.
+	 */
+	void addOutput(Memory memory);
+	
+	/**
+	 * Gets the input memories list.
+	 * 
+	 * @return the inputs.
+	 */
+	List<Memory> getInputs();
+	
+	/**
+	 * Add one memory to the input list.
+	 * 
+	 * @param memory
+	 *            one input to set.
+	 */
+	void addInput(Memory memory);
+
+}

--- a/src/main/java/br/unicamp/meca/system2/codelets/SoarCodelet.java
+++ b/src/main/java/br/unicamp/meca/system2/codelets/SoarCodelet.java
@@ -32,7 +32,7 @@ import br.unicamp.meca.memory.WorkingMemory;
  * @author W. Gibaut
  * @see br.unicamp.cst.bindings.soar.JSoarCodelet
  */
-public abstract class SoarCodelet extends br.unicamp.cst.bindings.soar.JSoarCodelet {
+public abstract class SoarCodelet extends br.unicamp.cst.bindings.soar.JSoarCodelet implements IPlanningCodelet {
 
 	private String id;
 

--- a/src/test/java/br/unicamp/meca/mind/MecaMindTest.java
+++ b/src/test/java/br/unicamp/meca/mind/MecaMindTest.java
@@ -26,6 +26,7 @@ import br.unicamp.meca.mind.motivational.TestMotivationalFromPerceptionCodelet;
 import br.unicamp.meca.mind.motivational.TestMotivationalFromPlanningCodelet;
 import br.unicamp.meca.mind.motor.TestMotorCodelet;
 import br.unicamp.meca.mind.perceptual.TestPerceptualCodelet;
+import br.unicamp.meca.mind.planning.TestSoarCodelet;
 import br.unicamp.meca.mind.sensory.TestPerceptionSensoryCodelet;
 import br.unicamp.meca.mind.sensory.TestPlanningSensoryCodelet;
 import br.unicamp.meca.models.ActionSequencePlan;
@@ -36,6 +37,7 @@ import br.unicamp.meca.system1.codelets.IMotorCodelet;
 import br.unicamp.meca.system1.codelets.ISensoryCodelet;
 import br.unicamp.meca.system1.codelets.MotivationalCodelet;
 import br.unicamp.meca.system1.codelets.PerceptualCodelet;
+import br.unicamp.meca.system2.codelets.IPlanningCodelet;
 
 /**
  * @author andre
@@ -60,6 +62,8 @@ public class MecaMindTest {
 	private static List<MotivationalCodelet> motivationalCodelets;
 	
 	private static List<ActivityCodelet> activityCodelets;
+	
+	private static IPlanningCodelet planningCodelet;
 
 	@BeforeClass
 	public static void setup() throws InterruptedException {
@@ -135,6 +139,8 @@ public class MecaMindTest {
 
 		Test1ActivityCodelet test1ActivityCodelet = new Test1ActivityCodelet("Test1Activity", perceptualPerceptionCodeletsIds, testMotivationalFromPerceptionCodeletIds, testMotorCodelet.getId(), null);
 		activityCodelets.add(test1ActivityCodelet);
+		
+		planningCodelet = new TestSoarCodelet("soar");
 	
 
 		/*
@@ -145,6 +151,7 @@ public class MecaMindTest {
 		mecaMind.setPerceptualCodelets(perceptualCodelets);
 		mecaMind.setMotivationalCodelets(motivationalCodelets);
 		mecaMind.setActivityCodelets(activityCodelets);
+		mecaMind.setPlanningCodelet(planningCodelet);
 	
 
 	}

--- a/src/test/java/br/unicamp/meca/mind/planning/TestSoarCodelet.java
+++ b/src/test/java/br/unicamp/meca/mind/planning/TestSoarCodelet.java
@@ -1,0 +1,49 @@
+/**
+ * 
+ */
+package br.unicamp.meca.mind.planning;
+
+import java.io.File;
+
+import br.unicamp.meca.system2.codelets.SoarCodelet;
+
+/**
+ * @author andre
+ *
+ */
+public class TestSoarCodelet extends SoarCodelet {
+
+	/**
+	 * @param id
+	 */
+	public TestSoarCodelet(String id) {
+		super(id);
+		// TODO Auto-generated constructor stub
+	}
+
+	/**
+	 * @param id
+	 * @param path_to_commands
+	 * @param _agentName
+	 * @param _productionPath
+	 * @param startSOARDebugger
+	 */
+	public TestSoarCodelet(String id, String path_to_commands, String _agentName, File _productionPath,
+			Boolean startSOARDebugger) {
+		super(id, path_to_commands, _agentName, _productionPath, startSOARDebugger);
+		// TODO Auto-generated constructor stub
+	}
+
+	@Override
+	public void fromPlanToAction() {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void calculateActivation() {
+		// TODO Auto-generated method stub
+
+	}
+
+}


### PR DESCRIPTION
### Why was it necessary?

[Generalization of the SoarCodelet as a PlanningCodelet](https://github.com/CST-Group/meca/issues/27)

### How was it done?

An interface called `IPlanningCodelet` was created to generalize the use of SoarCodelet in mounting the MECA mind. A few bits and pieces of refactoring was done here and there.

Now, other Planning Codelets can be created implementing the same interface to be used replacing the SoarCodelet as well.

### How to test?

Run `./gradlew clean build`.

Alternatively, you can test this build in one of your applications importing it in your `build.gradle` as:

`implementation 'com.github.CST-Group:meca:45b33010547fedbed5508ac4828aa81d2684587f'`
