### PR TITLE
Upgrade to cst desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Note: This library is still under development, and some concepts or features mig
 ```
 	dependencies {
             ...
-            implementation 'com.github.CST-Group:meca:0.6.0'
+            implementation 'com.github.CST-Group:meca:0.7.0'
 	}
 ```
 
@@ -54,7 +54,7 @@ Sometimes, the version number (tag) in this README gets out of date, as maintain
 	<dependency>
 	    <groupId>com.github.CST-Group</groupId>
 	    <artifactId>meca</artifactId>
-	    <version>0.6.0</version>
+	    <version>0.7.0</version>
 	</dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,19 +18,20 @@ repositories {
     }
     mavenCentral()
     maven { url 'https://jitpack.io' }
-    maven { 
-    	url "https://github.com/rosjava/rosjava_mvn_repo/raw/master"
+    maven {
+        url "https://github.com/rosjava/rosjava_mvn_repo/raw/master"
     }
     maven {
-      url "https://repository.springsource.com/maven/bundles/release"
-    }
-    maven {
-      url "https://repository.springsource.com/maven/bundles/external"
+        url "https://artifacts.camunda.com/artifactory/public/"
     }
 }
 
+configurations {
+    extraLibs
+}
+
 dependencies {
-   api('com.github.CST-Group:cst:0.7.0') 
+   api('com.github.CST-Group:cst-desktop:1.1.0') 
    api 'org.ros.rosjava_messages:std_msgs:0.5.11'
    //api ':cst:0.6.2-full'
    testImplementation group: 'junit', name: 'junit', version: '4.12'
@@ -53,21 +54,25 @@ jar {
 }
 
 task javadocJar(type: Jar) {
-    classifier = 'javadoc'
+    archiveClassifier = 'javadoc'
     from javadoc
+    from {
+    	configurations.extraLibs.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+    javadoc.options.addStringOption('Xdoclint:none', '-quiet') // this is to avoid complaints about documentation missing parameter description
 }
 task sourcesJar(type: Jar) {
-    classifier = 'sources'
+    archiveClassifier = 'sources'
     from sourceSets.main.allSource
-}
-task uberJar(type: Jar) {
-    archiveClassifier = 'full'
-    manifest {
-      attributes(
-        'Class-Path': configurations.runtimeClasspath.files.collect { it.getName() }.join(' ')    
-      )
-      
+    from {
+        configurations.extraLibs.collect { it.isDirectory() ? it : zipTree(it) }
     }
+}
+
+
+task uberJar(type: Jar) {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    archiveClassifier = 'full'
     from sourceSets.main.output
     dependsOn configurations.runtimeClasspath
     from {
@@ -75,6 +80,7 @@ task uberJar(type: Jar) {
     }
     exclude 'META-INF/*.RSA', 'META-INF/*.SF','META-INF/*.DSA'
 }
+
 artifacts
 {
     archives javadocJar, sourcesJar, uberJar
@@ -90,6 +96,6 @@ publishing {
 
 jacocoTestReport {
     reports {
-        xml.enabled true
+        xml.required = true
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ description = "The Multipurpose Enhanced Cognitive Architecture (MECA)"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
-version = '0.6.0'
+version = '0.7.0'
 
 repositories {
     flatDir {
@@ -33,7 +33,6 @@ configurations {
 dependencies {
    api('com.github.CST-Group:cst-desktop:1.1.0') 
    api 'org.ros.rosjava_messages:std_msgs:0.5.11'
-   //api ':cst:0.6.2-full'
    testImplementation group: 'junit', name: 'junit', version: '4.12'
    testImplementation 'org.ros.rosjava_messages:std_msgs:0.5.11'
    testImplementation 'org.ros.rosjava_messages:rosjava_test_msgs:0.3.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/br/unicamp/meca/mind/MecaMind.java
+++ b/src/main/java/br/unicamp/meca/mind/MecaMind.java
@@ -24,6 +24,7 @@ import br.unicamp.cst.core.entities.Memory;
 import br.unicamp.cst.core.entities.MemoryContainer;
 import br.unicamp.cst.core.entities.MemoryObject;
 import br.unicamp.cst.core.entities.Mind;
+import br.unicamp.cst.bindings.soar.PlansSubsystemModule;
 import br.unicamp.meca.memory.WorkingMemory;
 import br.unicamp.meca.system1.codelets.ActivityCodelet;
 import br.unicamp.meca.system1.codelets.ActivityTrackingCodelet;
@@ -76,7 +77,8 @@ public class MecaMind extends Mind {
 	private Memory actionSequencePlanMemoryContainer;
 	private Memory actionSequencePlanRequestMemoryContainer;
 	private ActivityTrackingCodelet activityTrackingCodelet;
-    private static HashMap<String,String> memoryGroups = new HashMap();
+        private static HashMap<String,String> memoryGroups = new HashMap();
+        private PlansSubsystemModule plansSubsystemModule = new PlansSubsystemModule();
 
 	/*
 	 * System 2
@@ -956,4 +958,8 @@ public class MecaMind extends Mind {
 	public void setPlanningCodelet(IPlanningCodelet planningCodelet) {
 		this.planningCodelet = planningCodelet;
 	}
+        
+        public PlansSubsystemModule getPlansSubsystemModule() {
+            return plansSubsystemModule;
+        }
 }

--- a/src/main/java/br/unicamp/meca/system1/codelets/AttentionCodelet.java
+++ b/src/main/java/br/unicamp/meca/system1/codelets/AttentionCodelet.java
@@ -18,7 +18,7 @@ import java.util.List;
 import br.unicamp.cst.core.entities.Codelet;
 import br.unicamp.cst.core.entities.Memory;
 import br.unicamp.cst.core.exceptions.CodeletActivationBoundsException;
-import br.unicamp.cst.representation.wme.Idea;
+import br.unicamp.cst.representation.idea.Idea;
 
 /**
  * This class represents a MECA Attention Codelet in System 1. Attention

--- a/src/main/java/br/unicamp/meca/system2/codelets/GoalCodelet.java
+++ b/src/main/java/br/unicamp/meca/system2/codelets/GoalCodelet.java
@@ -14,7 +14,7 @@ package br.unicamp.meca.system2.codelets;
 
 import br.unicamp.cst.core.entities.Memory;
 import br.unicamp.cst.core.entities.MemoryContainer;
-import br.unicamp.cst.representation.wme.Idea;
+import br.unicamp.cst.representation.idea.Idea;
 import br.unicamp.meca.memory.WorkingMemory;
 
 /**

--- a/src/main/java/br/unicamp/meca/system2/codelets/SoarCodelet.java
+++ b/src/main/java/br/unicamp/meca/system2/codelets/SoarCodelet.java
@@ -18,7 +18,7 @@ import java.util.Collections;
 import java.util.List;
 
 import br.unicamp.cst.core.entities.Memory;
-import br.unicamp.cst.representation.wme.Idea;
+import br.unicamp.cst.representation.idea.Idea;
 import br.unicamp.meca.memory.WorkingMemory;
 
 /**

--- a/src/test/java/br/unicamp/meca/mind/MecaMindTest.java
+++ b/src/test/java/br/unicamp/meca/mind/MecaMindTest.java
@@ -17,7 +17,7 @@ import br.unicamp.cst.core.entities.Codelet;
 import br.unicamp.cst.core.entities.Memory;
 import br.unicamp.cst.core.entities.MemoryContainer;
 import br.unicamp.cst.core.exceptions.CodeletActivationBoundsException;
-import br.unicamp.cst.util.MindViewer;
+import br.unicamp.cst.util.viewer.MindViewer;
 import br.unicamp.meca.mind.action.Test1ActivityCodelet;
 import br.unicamp.meca.mind.action.Test2ActivityCodelet;
 import br.unicamp.meca.mind.action.Test3ActivityCodelet;


### PR DESCRIPTION
### Why was it necessary?

The old MECA was still using CST 0.7.0. Now we are upgrading to the newest cst-desktop with CST 1.5.0

### How was it done?

We had to make updates in the affected classes

### Implementation details

Just the necessary to make it compatible to the new structures in CST 1.5.0


### How to test?

Run the unit tests

### Future works

Optimize the PlanSubsystemModule